### PR TITLE
StateMachineのget_classにnullが入らないよう修正

### DIFF
--- a/src/Finite/StateMachine/StateMachine.php
+++ b/src/Finite/StateMachine/StateMachine.php
@@ -124,7 +124,7 @@ class StateMachine implements StateMachineInterface
                 'The "%s" transition can not be applied to the "%s" state of object "%s" with graph "%s".',
                 $transition->getName(),
                 $this->currentState->getName(),
-                empty($this->getObject())? '' : get_class($this->getObject()),
+                empty($this->getObject())? '( not object )' : get_class($this->getObject()),
                 $this->getGraph()
             ));
         }
@@ -223,7 +223,7 @@ class StateMachine implements StateMachineInterface
             throw new Exception\TransitionException(sprintf(
                 'Unable to find a transition called "%s" on object "%s" with graph "%s".',
                 $name,
-                empty($this->getObject())? '' : get_class($this->getObject()),
+                empty($this->getObject())? '( not object )' : get_class($this->getObject()),
                 $this->getGraph()
             ));
         }
@@ -242,7 +242,7 @@ class StateMachine implements StateMachineInterface
             throw new Exception\StateException(sprintf(
                 'Unable to find a state called "%s" on object "%s" with graph "%s".',
                 $name,
-                empty($this->getObject())? '' : get_class($this->getObject()),
+                empty($this->getObject())? '( not object )' : get_class($this->getObject()),
                 $this->getGraph()
             ));
         }
@@ -307,7 +307,7 @@ class StateMachine implements StateMachineInterface
 
         throw new Exception\StateException(sprintf(
             'No initial state found on object "%s" with graph "%s".',
-            empty($this->getObject())? '' : get_class($this->getObject()),
+            empty($this->getObject())? '( not object )' : get_class($this->getObject()),
             $this->getGraph()
         ));
     }

--- a/src/Finite/StateMachine/StateMachine.php
+++ b/src/Finite/StateMachine/StateMachine.php
@@ -124,7 +124,7 @@ class StateMachine implements StateMachineInterface
                 'The "%s" transition can not be applied to the "%s" state of object "%s" with graph "%s".',
                 $transition->getName(),
                 $this->currentState->getName(),
-                get_class($this->getObject()),
+                empty($this->getObject())? '' : get_class($this->getObject()),
                 $this->getGraph()
             ));
         }
@@ -223,7 +223,7 @@ class StateMachine implements StateMachineInterface
             throw new Exception\TransitionException(sprintf(
                 'Unable to find a transition called "%s" on object "%s" with graph "%s".',
                 $name,
-                get_class($this->getObject()),
+                empty($this->getObject())? '' : get_class($this->getObject()),
                 $this->getGraph()
             ));
         }
@@ -242,7 +242,7 @@ class StateMachine implements StateMachineInterface
             throw new Exception\StateException(sprintf(
                 'Unable to find a state called "%s" on object "%s" with graph "%s".',
                 $name,
-                get_class($this->getObject()),
+                empty($this->getObject())? '' : get_class($this->getObject()),
                 $this->getGraph()
             ));
         }
@@ -307,7 +307,7 @@ class StateMachine implements StateMachineInterface
 
         throw new Exception\StateException(sprintf(
             'No initial state found on object "%s" with graph "%s".',
-            get_class($this->getObject()),
+            empty($this->getObject())? '' : get_class($this->getObject()),
             $this->getGraph()
         ));
     }


### PR DESCRIPTION
PHP7.1からPHP7.4にバージョンアップする時に、get_classの引数にnullが入ってエラーが発生するため対応